### PR TITLE
Receive webhook events from GitHub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "axum"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de45108900e1f9b9242f7f2e254aa3e2c029c921c258fe9e6b4217eeebd54288"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,6 +543,7 @@ name = "hero"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "axum",
  "clap",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -546,6 +601,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,6 +619,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -865,6 +927,12 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -1501,6 +1569,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1868,6 +1946,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1888,6 +1967,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 
 [dependencies]
 anyhow = "1.0.97"
+axum = "0.8.3"
 clap = { version = "4.5.32", features = ["wrap_help"] }
 opentelemetry = { version = "0.29.0", features = ["trace"] }
 opentelemetry-otlp = { version = "0.29.0", features = ["trace", "grpc-tonic"] }

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ $ otelcol --config otel-collector-config.yaml
 
 An example config file can be found in the _doc/_ directory; just enter an
 appropriate Ingest Key for the Honeycomb environment you wish to send to.
-Traces will appear in the `github-builds` service dataset.
+Traces will appear in the `github-actions` service dataset.
 
 ## Development
 

--- a/src/github.rs
+++ b/src/github.rs
@@ -8,6 +8,7 @@ use tracing::debug;
 use tracing::info;
 
 use crate::VERSION;
+use crate::get_program_start;
 
 /// A struct holding the configuration being used to retrieve information from
 /// GitHub's API.
@@ -16,7 +17,6 @@ pub(crate) struct Config {
     pub(crate) repository: String,
     pub(crate) workflow: String,
     pub(crate) devel: bool,
-    pub(crate) program_start: OffsetDateTime,
 }
 
 #[derive(Debug, Deserialize)]
@@ -74,7 +74,8 @@ pub(crate) async fn retrieve_workflow_runs(
         // mode. This delta will be added to all timestamps to bring them to
         // near program start time (ie now).
         let delta = if config.devel {
-            config.program_start - run.created_at - Duration::minutes(10)
+            let program_start = *get_program_start();
+            program_start - run.created_at - Duration::minutes(10)
         } else {
             Duration::ZERO
         };

--- a/src/github.rs
+++ b/src/github.rs
@@ -19,13 +19,22 @@ pub(crate) struct Config {
     pub(crate) devel: bool,
 }
 
+// We have structs for all the relevant objects in the GitHub API. This was
+// initially created by the responses for the various GitHub Actions Workflow
+// Run responses, but it turns out the payload for the webhook is the same
+// object, so we were able to re-use this.
+
 #[derive(Debug, Deserialize)]
 pub(crate) struct WorkflowRun {
+    pub(crate) actor: WorkflowActor,
     #[serde(rename = "id")]
     pub(crate) run_id: u64,
     pub(crate) run_number: u64,
     pub(crate) run_attempt: u64,
+    pub(crate) head_branch: String,
     pub(crate) name: String,
+    pub(crate) display_title: String,
+    pub(crate) event: String, // what caused the workflow to run
     pub(crate) status: String,
     pub(crate) conclusion: String,
     #[serde(with = "rfc3339")]
@@ -33,9 +42,15 @@ pub(crate) struct WorkflowRun {
     #[serde(with = "rfc3339")]
     pub(crate) updated_at: OffsetDateTime,
     pub(crate) html_url: String,
+    pub(crate) path: String, // the full path and version of the workflow code
+
     // and now our fields that are NOT in the response object
     #[serde(default)]
     pub(crate) delta: Duration,
+}
+#[derive(Debug, Deserialize)]
+pub(crate) struct WorkflowActor {
+    pub(crate) login: String,
 }
 
 #[derive(Deserialize)]

--- a/src/github.rs
+++ b/src/github.rs
@@ -11,7 +11,7 @@ use crate::VERSION;
 
 /// A struct holding the configuration being used to retrieve information from
 /// GitHub's API.
-pub(crate) struct API {
+pub(crate) struct Config {
     pub(crate) owner: String,
     pub(crate) repository: String,
     pub(crate) workflow: String,
@@ -44,7 +44,7 @@ struct ResponseRuns {
 }
 
 pub(crate) async fn retrieve_workflow_runs(
-    config: &API,
+    config: &Config,
     client: &reqwest::Client,
     count: u32,
 ) -> Result<Vec<WorkflowRun>> {
@@ -117,7 +117,7 @@ struct ResponseJobs {
 }
 
 pub(crate) async fn retrieve_run_jobs(
-    config: &API,
+    config: &Config,
     client: &reqwest::Client,
     run: &WorkflowRun,
 ) -> Result<Vec<WorkflowJob>> {

--- a/src/github.rs
+++ b/src/github.rs
@@ -12,7 +12,6 @@ use crate::VERSION;
 /// A struct holding the configuration being used to retrieve information from
 /// GitHub's API.
 pub(crate) struct API {
-    pub(crate) client: reqwest::Client,
     pub(crate) owner: String,
     pub(crate) repository: String,
     pub(crate) workflow: String,
@@ -44,7 +43,11 @@ struct ResponseRuns {
     workflow_runs: Vec<WorkflowRun>,
 }
 
-pub(crate) async fn retrieve_workflow_runs(config: &API, count: u32) -> Result<Vec<WorkflowRun>> {
+pub(crate) async fn retrieve_workflow_runs(
+    config: &API,
+    client: &reqwest::Client,
+    count: u32,
+) -> Result<Vec<WorkflowRun>> {
     // use token to retrieve runs for the given workflow from GitHub API
     info!("List Runs for Workflow {}", config.workflow);
 
@@ -54,8 +57,7 @@ pub(crate) async fn retrieve_workflow_runs(config: &API, count: u32) -> Result<V
     );
     debug!(?url);
 
-    let response = config
-        .client
+    let response = client
         .get(&url)
         .send()
         .await?;
@@ -114,7 +116,11 @@ struct ResponseJobs {
     jobs: Vec<WorkflowJob>,
 }
 
-pub(crate) async fn retrieve_run_jobs(config: &API, run: &WorkflowRun) -> Result<Vec<WorkflowJob>> {
+pub(crate) async fn retrieve_run_jobs(
+    config: &API,
+    client: &reqwest::Client,
+    run: &WorkflowRun,
+) -> Result<Vec<WorkflowJob>> {
     info!("List Jobs in Run {}", run.run_id);
     let url = format!(
         "https://api.github.com/repos/{}/{}/actions/runs/{}/jobs",
@@ -123,8 +129,7 @@ pub(crate) async fn retrieve_run_jobs(config: &API, run: &WorkflowRun) -> Result
 
     debug!(?url);
 
-    let response = config
-        .client
+    let response = client
         .get(url)
         .send()
         .await?;

--- a/src/history.rs
+++ b/src/history.rs
@@ -5,7 +5,7 @@ use std::{
 };
 use tracing::{debug, info};
 
-use crate::github::{API, WorkflowRun};
+use crate::github::{Config, WorkflowRun};
 
 pub(crate) fn ensure_record_directory(prefix: &str) -> Result<()> {
     let path = Path::new(prefix);
@@ -15,7 +15,7 @@ pub(crate) fn ensure_record_directory(prefix: &str) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn form_record_filename(prefix: &str, config: &API, run: &WorkflowRun) -> PathBuf {
+pub(crate) fn form_record_filename(prefix: &str, config: &Config, run: &WorkflowRun) -> PathBuf {
     let id = format!("{}", run.run_id);
 
     let name = format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,22 +61,34 @@ async fn main() -> Result<()> {
                     .global(true)
                     .hide(true)
                     .action(ArgAction::Version))
-            .arg(
-                Arg::new("count")
-                    .long("count" )
-                    .long_help("The number of Runs for the specified Workflow to retrieve from GitHub and upload to Honeycomb. The default if unspecified is to check the 10 most recent Runs.")
-                    .global(true)
-                )
-            .arg(
-                Arg::new("repository")
-                    .action(ArgAction::Set)
-                    .required(true)
-                    .help("Name of the GitHub organization and repository to retrieve workflows from. This must be specified in the form \"owner/repo\""))
-            .arg(
-                Arg::new("workflow")
-                    .action(ArgAction::Set)
-                    .required(true)
-                    .help("Name of the GitHub Actions workflow to present as a trace. This is typically a filename such as \"check.yaml\""))
+            .subcommand(
+                Command::new("listen")
+                        .about("Run HTTP server to receive webhook events from GitHub")
+                                .arg(Arg::new("port")
+                                    .long("port")
+                                    .long_help("Override the port the receiver will listen on. The default is port 34484")
+                                )
+            )
+            .subcommand(
+                Command::new("query")
+                        .about("Query workflow runs directly")
+                        .arg(
+                            Arg::new("count")
+                                .long("count" )
+                                .long_help("The number of Runs for the specified Workflow to retrieve from GitHub and upload to Honeycomb. The default if unspecified is to check the 10 most recent Runs.")
+                            )
+                        .arg(
+                                Arg::new("repository")
+                                    .action(ArgAction::Set)
+                                    .required(true)
+                                    .help("Name of the GitHub organization and repository to retrieve workflows from. This must be specified in the form \"owner/repo\""))
+                            .arg(
+                                Arg::new("workflow")
+                                    .action(ArgAction::Set)
+                                    .required(true)
+                                    .help("Name of the GitHub Actions workflow to present as a trace. This is typically a filename such as \"check.yaml\""))
+
+            )
             .get_matches();
 
     // when developing we reset all the start times to be offset from when
@@ -86,6 +98,18 @@ async fn main() -> Result<()> {
     let devel = !devel.is_empty();
 
     let program_start = OffsetDateTime::now_utc();
+
+    match matches.subcommand() {
+        Some(("listen", submatches)) => {}
+        Some(("query", submatches)) => {}
+        Some(_) => {
+            println!("No valid subcommand was used")
+        }
+        None => {
+            println!("usage: hero [COMMAND] ...");
+            println!("Try '--help' for more information.");
+        }
+    }
 
     // Now we get the details of what repository we're going to get the Action
     // history from.

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,7 +168,7 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-async fn run_listen(config: &Config, port: u32) -> Result<()> {
+async fn run_listen(_config: &Config, port: u32) -> Result<()> {
     webhook::run_webserver(port).await
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,7 +206,11 @@ async fn run_query(config: &Config, count: u32) -> Result<()> {
     Ok(())
 }
 
-async fn process_run(config: &Config, client: &reqwest::Client, run: &WorkflowRun) -> Result<String> {
+async fn process_run(
+    config: &Config,
+    client: &reqwest::Client,
+    run: &WorkflowRun,
+) -> Result<String> {
     info!("Processing Run {}", run.run_id);
 
     let context = traces::establish_root_context(&config, &run);

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,8 +97,7 @@ async fn main() -> Result<()> {
     // when developing we reset all the start times to be offset from when
     // this program started running.
 
-    let devel = std::env::var("HERO_DEVELOPER")?;
-    let devel = !devel.is_empty();
+    let devel = std::env::var("HERO_DEVELOPER").is_ok();
 
     match matches.subcommand() {
         Some(("listen", submatches)) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ mod history;
 mod traces;
 mod webhook;
 
-use github::{API, WorkflowJob, WorkflowRun};
+use github::{Config, WorkflowJob, WorkflowRun};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -100,7 +100,7 @@ async fn main() -> Result<()> {
             let repository = String::new();
             let workflow = String::new();
 
-            let config = API {
+            let config = Config {
                 owner,
                 repository,
                 workflow,
@@ -135,7 +135,7 @@ async fn main() -> Result<()> {
 
             debug!(workflow);
 
-            let config = API {
+            let config = Config {
                 owner,
                 repository,
                 workflow,
@@ -168,11 +168,11 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-async fn run_listen(config: &API, port: u32) -> Result<()> {
+async fn run_listen(config: &Config, port: u32) -> Result<()> {
     webhook::run_webserver(port).await
 }
 
-async fn run_query(config: &API, count: u32) -> Result<()> {
+async fn run_query(config: &Config, count: u32) -> Result<()> {
     let client = github::setup_api_client()?;
 
     let runs: Vec<WorkflowRun> = github::retrieve_workflow_runs(&config, &client, count).await?;
@@ -194,7 +194,7 @@ async fn run_query(config: &API, count: u32) -> Result<()> {
     Ok(())
 }
 
-async fn process_run(config: &API, client: &reqwest::Client, run: &WorkflowRun) -> Result<String> {
+async fn process_run(config: &Config, client: &reqwest::Client, run: &WorkflowRun) -> Result<String> {
     info!("Processing Run {}", run.run_id);
 
     let context = traces::establish_root_context(&config, &run);

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ const PREFIX: &str = "record";
 mod github;
 mod history;
 mod traces;
+mod webhook;
 
 use github::{API, WorkflowJob, WorkflowRun};
 

--- a/src/traces.rs
+++ b/src/traces.rs
@@ -14,7 +14,7 @@ use time::OffsetDateTime;
 use tracing::debug;
 
 use crate::VERSION;
-use crate::github::{API, WorkflowJob, WorkflowRun};
+use crate::github::{Config, WorkflowJob, WorkflowRun};
 
 /// It turns out that the OpenTelemetry API uses std::time::SystemTime to
 /// represent start and end times (which makes sense, given that is mostly
@@ -27,7 +27,7 @@ fn convert_to_system_time(datetime: &OffsetDateTime) -> SystemTime {
         .into()
 }
 
-fn form_trace_id(config: &API, run_id: u64) -> TraceId {
+fn form_trace_id(config: &Config, run_id: u64) -> TraceId {
     let input = format!(
         "{}:{}:{}:{}",
         config.owner, config.repository, config.workflow, run_id
@@ -142,7 +142,7 @@ pub(crate) fn display_job_steps(context: &Context, run: &WorkflowRun, jobs: Vec<
     }
 }
 
-pub(crate) fn establish_root_context(config: &API, run: &WorkflowRun) -> Context {
+pub(crate) fn establish_root_context(config: &Config, run: &WorkflowRun) -> Context {
     let provider = global::tracer_provider();
     let tracer = provider.tracer(module_path!());
 

--- a/src/traces.rs
+++ b/src/traces.rs
@@ -245,7 +245,7 @@ pub(crate) fn setup_telemetry_machinery() -> SdkTracerProvider {
 
     let resource = Resource::builder()
         .with_attributes([
-            KeyValue::new(SERVICE_NAME, "github-builds"),
+            KeyValue::new(SERVICE_NAME, "github-actions"),
             KeyValue::new(SERVICE_VERSION, VERSION),
         ])
         .build();

--- a/src/traces.rs
+++ b/src/traces.rs
@@ -6,6 +6,7 @@ use opentelemetry_otlp::SpanExporter;
 use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::trace::SdkTracerProvider;
 use opentelemetry_semantic_conventions::attribute::{SERVICE_NAME, SERVICE_VERSION};
+use std::borrow::Cow;
 use std::process;
 // use opentelemetry_stdout::SpanExporter;
 use sha2::Digest;
@@ -131,6 +132,13 @@ pub(crate) fn display_job_steps(context: &Context, run: &WorkflowRun, jobs: Vec<
             // will create the new Span as a child of that one as parent!
             let mut span = tracer.build_with_context(builder, &context);
             span.set_attribute(KeyValue::new("status", step.status));
+
+            if step.conclusion == "failure" {
+                span.set_status(opentelemetry::trace::Status::Error {
+                    description: Cow::Borrowed("Step failed"),
+                });
+            }
+            span.set_attribute(KeyValue::new("conclusion", step.conclusion));
 
             span.end_with_timestamp(step_finish);
         }

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -5,10 +5,7 @@ use anyhow::Result;
 use axum::Json;
 use axum::{Router, routing::get};
 use serde::Deserialize;
-use tracing::debug;
 use tracing::info;
-
-use crate::VERSION;
 
 pub(crate) async fn run_webserver(port: u32) -> Result<()> {
     let router = Router::new().route("/", get(hello_world).post(receive_post));

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -10,10 +10,11 @@ use tracing::info;
 
 use crate::VERSION;
 
-pub(crate) async fn run_webserver() -> Result<()> {
+pub(crate) async fn run_webserver(port: u32) -> Result<()> {
     let router = Router::new().route("/", get(hello_world));
 
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:34484").await?;
+    let address = format!("127.0.0.1:{}", port);
+    let listener = tokio::net::TcpListener::bind(address).await?;
     axum::serve(listener, router).await?;
 
     Ok(())

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -1,9 +1,8 @@
 //! This is a module to receive webhooks from GitHub when a GitHub Action
 //! workflow is run.
 
-use std::f64::consts::PI;
-
 use anyhow::Result;
+use axum::Json;
 use axum::{Router, routing::get};
 use tracing::debug;
 use tracing::info;
@@ -11,9 +10,11 @@ use tracing::info;
 use crate::VERSION;
 
 pub(crate) async fn run_webserver(port: u32) -> Result<()> {
-    let router = Router::new().route("/", get(hello_world));
+    let router = Router::new().route("/", get(hello_world).post(receive_post));
 
     let address = format!("127.0.0.1:{}", port);
+    info!("Listening on {}", address);
+
     let listener = tokio::net::TcpListener::bind(address).await?;
     axum::serve(listener, router).await?;
 
@@ -22,4 +23,8 @@ pub(crate) async fn run_webserver(port: u32) -> Result<()> {
 
 async fn hello_world() -> &'static str {
     "Hello world!"
+}
+
+async fn receive_post(Json(value): Json<serde_json::Value>) {
+    debug!(?value)
 }

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -1,0 +1,24 @@
+//! This is a module to receive webhooks from GitHub when a GitHub Action
+//! workflow is run.
+
+use std::f64::consts::PI;
+
+use anyhow::Result;
+use axum::{Router, routing::get};
+use tracing::debug;
+use tracing::info;
+
+use crate::VERSION;
+
+pub(crate) async fn run_webserver() -> Result<()> {
+    let router = Router::new().route("/", get(hello_world));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:34484").await?;
+    axum::serve(listener, router).await?;
+
+    Ok(())
+}
+
+async fn hello_world() -> &'static str {
+    "Hello world!"
+}

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -4,6 +4,7 @@
 use anyhow::Result;
 use axum::Json;
 use axum::{Router, routing::get};
+use serde::Deserialize;
 use tracing::debug;
 use tracing::info;
 
@@ -21,10 +22,77 @@ pub(crate) async fn run_webserver(port: u32) -> Result<()> {
     Ok(())
 }
 
+#[derive(Deserialize)]
+struct RequestPayload {
+    action: String,
+    organization: WebhookOrganization,
+    repository: WebhookRepository,
+    workflow_run: WebhookWorkflowRun,
+}
+
+#[derive(Deserialize)]
+struct WebhookOrganization {
+    login: String,
+}
+
+#[derive(Deserialize)]
+struct WebhookRepository {
+    name: String,
+}
+
+#[derive(Deserialize)]
+struct WebhookWorkflowRun {
+    actor: WebhookActor,
+    conclusion: String,
+    display_title: String,
+    event: String,
+    head_branch: String,
+    path: String,
+}
+
+#[derive(Deserialize)]
+struct WebhookActor {
+    login: String,
+}
+
 async fn hello_world() -> &'static str {
     "Hello world!"
 }
 
-async fn receive_post(Json(value): Json<serde_json::Value>) {
-    println!("{}", serde_json::to_string_pretty(&value).unwrap())
+async fn receive_post(Json(payload): Json<RequestPayload>) {
+    let path = payload
+        .workflow_run
+        .path;
+    let filename = path
+        .split('/')
+        .last()
+        .unwrap();
+
+    println!(
+        "{}: {}/{} {} \"{}\" by {} via {} for {}: {}",
+        payload.action,
+        payload
+            .organization
+            .login,
+        payload
+            .repository
+            .name,
+        filename,
+        payload
+            .workflow_run
+            .display_title,
+        payload
+            .workflow_run
+            .actor
+            .login,
+        payload
+            .workflow_run
+            .event,
+        payload
+            .workflow_run
+            .head_branch,
+        payload
+            .workflow_run
+            .conclusion
+    );
 }

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -26,5 +26,5 @@ async fn hello_world() -> &'static str {
 }
 
 async fn receive_post(Json(value): Json<serde_json::Value>) {
-    debug!(?value)
+    println!("{}", serde_json::to_string_pretty(&value).unwrap())
 }


### PR DESCRIPTION
Breaking change to command-line, adding two sub-commands, the original features being in the `query` sub-command, and a new `listen` which runs the server to listen for webhook events.

When run on public server that GitHub can reach, this mode will accept JSON bodies for the "Workflow Run" category, and then translate them into a trace of spans representing the workflow that was run and send to Honeycomb.