### PR TITLE
Scafolding for Debian package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,14 @@
 name = "hero"
 description = "Send GitHub Actions workflow history to OpenTelemetry as traces and spans"
 version = "0.1.0"
+license = "MIT"
+authors = [ "Andrew Cowie" ]
 edition = "2024"
+
+[package.metadata.deb]
+name = "action-hero"
+maintainer-scripts = "debian/"
+systemd-units = { unit-name = "action-hero", enable = false }
 
 [dependencies]
 anyhow = "1.0.97"

--- a/debian/action-hero.service
+++ b/debian/action-hero.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Action Hero
+
+[Service]
+LoadCredential=github
+Environment="RUST_LOG=hero=debug,*=warn"
+ExecStart=/usr/bin/hero listen
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Deploying a Rust binary on an arbitrary server isn't hard, but when wanting to run that program as a service it's better to have it properly installed on the filesystem. On a Debian or Ubuntu machine we use a _.deb_ package. Creating _those_ can be a pain in the ass.

Enter **cargo-deb**, which, with the help of a small amount of additional metadata in the _Cargo.toml_ file, can be used to create a Debian package that can be immediately installed. Further that plugin has facilities for deploying a systemd unit file into the right place which is brilliant.

This branch updates _Cargo.toml_ with the appropriate additional section, and adds a simple _.service_ unit file so Action Hero can be deployed on a Debian server.