### PR TITLE
Rename the credential for GitHub tokens

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ fn set_api_token() {
         Result::Err(_) => match std::env::var("CREDENTIALS_DIRECTORY") {
             Result::Ok(directory) => {
                 // form the target filename
-                let path = format!("{}/github", directory);
+                let path = format!("{}/receiver-github-token", directory);
 
                 // read the credential file
                 let contents = std::fs::read_to_string(&path)


### PR DESCRIPTION
Use a more detailed name for the file being looked for in `CREDENTIALS_DIRECTORY`. The original value _github_ was a bit generic, and if used in an environment with multiple secrets caused a potential collision. As this is deployed in a service called "event receiver" the new filename is _receiver_github_token_.