### PR TITLE
Improvements to runtime defaults

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,6 @@ use tracing_subscriber;
 
 const VERSION: &str = concat!("v", env!("CARGO_PKG_VERSION"));
 
-const PREFIX: &str = "record";
-
 static PROGRAM_START: OnceLock<OffsetDateTime> = OnceLock::new();
 
 fn set_program_start() {
@@ -76,8 +74,6 @@ async fn main() -> Result<()> {
     // Initialize the opentelemetry exporter
     let provider = traces::setup_telemetry_machinery();
 
-    history::ensure_record_directory(PREFIX)?;
-
     // Configure command-line argument parser
     let matches = Command::new("hero")
             .version(VERSION)
@@ -103,31 +99,36 @@ async fn main() -> Result<()> {
                     .action(ArgAction::Version))
             .subcommand(
                 Command::new("listen")
-                        .about("Run HTTP server to receive webhook events from GitHub")
-                                .arg(Arg::new("port")
-                                    .long("port")
-                                    .long_help("Override the port the receiver will listen on. The default is port 34484")
-                                )
+                    .about("Run HTTP server to receive webhook events from GitHub")
+                    .arg(Arg::new("port")
+                        .long("port")
+                        .long_help("Override the port the receiver will listen on. The default is port 34484")
+                    )
             )
             .subcommand(
                 Command::new("query")
-                        .about("Query workflow runs directly")
-                        .arg(
-                            Arg::new("count")
-                                .long("count" )
-                                .long_help("The number of Runs for the specified Workflow to retrieve from GitHub and upload to Honeycomb. The default if unspecified is to check the 10 most recent Runs.")
-                            )
-                        .arg(
-                                Arg::new("repository")
-                                    .action(ArgAction::Set)
-                                    .required(true)
-                                    .help("Name of the GitHub organization and repository to retrieve workflows from. This must be specified in the form \"owner/repo\""))
-                            .arg(
-                                Arg::new("workflow")
-                                    .action(ArgAction::Set)
-                                    .required(true)
-                                    .help("Name of the GitHub Actions workflow to present as a trace. This is typically a filename such as \"check.yaml\""))
-
+                    .about("Query workflow runs directly")
+                    .arg(
+                        Arg::new("count")
+                            .long("count" )
+                            .long_help("The number of Runs for the specified Workflow to retrieve from GitHub and upload to Honeycomb. The default if unspecified is to check the 10 most recent Runs.")
+                        )
+                    .arg(
+                        Arg::new("repository")
+                            .action(ArgAction::Set)
+                            .required(true)
+                            .long_help("Name of the GitHub organization and repository to retrieve workflows from. This must be specified in the form \"owner/repo\"."))
+                    .arg(
+                        Arg::new("workflow")
+                            .action(ArgAction::Set)
+                            .required(true)
+                            .help("Name of the GitHub Actions workflow to present as a trace. This is typically a filename such as \"check.yaml\"."))
+                    .arg(
+                        Arg::new("state-dir")
+                            .long("state-dir")
+                            .action(ArgAction::Set)
+                            .long_help("Directory where records of processed Runs are written. The default is \"record\" under the current working directory.")
+                        )
             )
             .get_matches();
 
@@ -191,7 +192,15 @@ async fn main() -> Result<()> {
                     .expect("Unable to parse supplied --count value"),
             };
 
-            run_query(&config, count).await?;
+            let state_dir = submatches.get_one::<String>("state-dir");
+            let state_dir = match state_dir {
+                None => "record",
+                Some(value) => value,
+            };
+
+            history::ensure_record_directory(state_dir)?;
+
+            run_query(&config, count, state_dir).await?;
         }
         Some(_) => {
             println!("No valid subcommand was used")
@@ -212,13 +221,13 @@ async fn run_listen(port: u32) -> Result<()> {
     webhook::run_webserver(port).await
 }
 
-async fn run_query(config: &Config, count: u32) -> Result<()> {
+async fn run_query(config: &Config, count: u32, prefix: &str) -> Result<()> {
     let client = github::setup_api_client()?;
 
     let runs: Vec<WorkflowRun> = github::retrieve_workflow_runs(&config, &client, count).await?;
 
     for run in &runs {
-        let path = history::form_record_filename(PREFIX, &config, run);
+        let path = history::form_record_filename(prefix, config, run);
 
         debug!(run.run_id);
 

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -1,6 +1,8 @@
 //! This is a module to receive webhooks from GitHub when a GitHub Action
 //! workflow is run.
 
+use std::net::Ipv4Addr;
+
 use anyhow::anyhow;
 use axum::Json;
 use axum::body::Body;
@@ -13,11 +15,11 @@ use tracing::info;
 
 use crate::github::{self, Config};
 
-pub(crate) async fn run_webserver(port: u32) -> anyhow::Result<()> {
+pub(crate) async fn run_webserver(host: Ipv4Addr, port: u16) -> anyhow::Result<()> {
     let router = Router::new().route("/", get(hello_world).post(receive_post));
 
-    let address = format!("127.0.0.1:{}", port);
-    info!("Listening on {}", address);
+    info!("Listening on {:?}:{}", host, port);
+    let address = (host, port);
 
     let listener = tokio::net::TcpListener::bind(address).await?;
     axum::serve(listener, router).await?;


### PR DESCRIPTION
Add a `--state-dir` option for `query` sub-command to allow overriding where the stamp files recording successful processing. The default remains _record/_ in _._.

Add a `--host` option for the `listen` sub-command (complementing the existing `--port` one) to allow specifying the address (interface) to bind to. The default is now `0.0.0.0`.